### PR TITLE
Fix install dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ rsa==4.9
 scikit-learn==1.2.2
 scipy==1.10.1
 sentence-transformers==2.2.2
-sentencepiece==0.1.97
+sentencepiece==0.1.99
 six==1.16.0
 sniffio==1.3.0
 SPARQLWrapper==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Deprecated==1.2.13
 duckdb==0.7.1
 et-xmlfile==1.1.0
 fastapi==0.95.0
-filelock==3.10.7
+filelock==3.12.0
 frozenlist==1.3.3
 google-api-core==2.11.0
 google-api-python-client==2.83.0


### PR DESCRIPTION
Related to [Issue#1](https://github.com/onlyphantom/llm-python/issues/2) but on macOS 13.4 and Rocky Linux 8

When I `pip install -r requirements.txt`, there are 2 errors:
```
Building wheel for sentencepiece (pyproject.toml) ... error                                                                                                 
  error: subprocess-exited-with-error                                                                                                                         
                                                                                                                                                              
  × Building wheel for sentencepiece (pyproject.toml) did not run successfully.                                                                               
  │ exit code: 1                                                                                                                                              
  ╰─> [97 lines of output]  
  
[...]
  
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
virtualenv 20.23.0 requires filelock<4,>=3.11, but you have filelock 3.10.7 which is incompatible.
  ```

When `requirements.txt` is updated from `sentencepiece==0.1.97` to `sentencepiece==0.1.99`, the issue is resolved first the 1st error, and updated from `filelock==3.10.7` to `filelock==3.12.0` resolved the second error.

`pip install -r requirements.txt` completes successfully with the version bump. 👍