### PR TITLE
fix: Import HuggingFaceHub & LLMChain separately

### DIFF
--- a/05_hf.py
+++ b/05_hf.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
-from langchain import HuggingFaceHub, LLMChain
+from langchain_community.llms import HuggingFaceHub 
+from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
 load_dotenv()


### PR DESCRIPTION
Importing the HuggingFaceHub & LLMChain classes above from the langchain root module throws two **UserWarning**s, preventing app from running.

The details of the `UserWarning` error thrown are as below: 
```
/home/mutuma/code/langchain_tutorials/llm-python/venv/lib/python3.10/site-packages/langchain/__init__.py:29: UserWarning: Importing HuggingFaceHub from langchain root module is no longer supported. Please use langchain_community.llms.HuggingFaceHub instead.
  warnings.warn(
/home/mutuma/code/langchain_tutorials/llm-python/venv/lib/python3.10/site-packages/langchain/__init__.py:29: UserWarning: Importing LLMChain from langchain root module is no longer supported. Please use langchain.chains.LLMChain instead.
  warnings.warn(
```
And the traceback is as below: 
```
Traceback (most recent call last):
  File "/home/mutuma/code/langchain_tutorials/llm-python/05_hf.py", line 19, in <module>
    hub_llm = HuggingFaceHub(
  File "/home/mutuma/code/langchain_tutorials/llm-python/venv/lib/python3.10/site-packages/langchain_core/_api/deprecation.py", line 183, in warn_if_direct_instance
    return wrapped(self, *args, **kwargs)
```

**Problem resolution:** I have replaced the single line import of the 2 classes by importing each class from the recommended sub-classes of the langchain module. 